### PR TITLE
Update readme to change include to prepend 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 Just include the module in your uploader:
 
     class ImageUploader < CarrierWave::Uploader::Base
-      include CarrierWave::MimetypeFu
+      prepend CarrierWave::MimetypeFu
     end
 
 And now uploaded files' content\_type will be set appropriately, and uploads will automatically be renamed before being passed on to the processors. Given a jpeg file named *test\_1.pdf*, the file will be renamed *test\_1.jpg* before being passed off to normal carrierwave processing.


### PR DESCRIPTION
# What does this PR do?

Since `alias_method_chain` has been [depreciated in Rails 5](https://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/), including the module in your uploader will throw an error in Rails 5 applications.

This can be circumvented quite easily by using `prepend` instead of `include` when adding the module to your uploader.

Some might consider this a dirty fix I guess, but I'm happy to discuss how much effort should be done to fix this issue :)